### PR TITLE
Dynamic synchronization

### DIFF
--- a/src/communication/data_by_rank.rs
+++ b/src/communication/data_by_rank.rs
@@ -10,6 +10,12 @@ use super::SizedCommunicator;
 
 pub struct DataByRank<T>(HashMap<Rank, T>);
 
+impl<T> Default for DataByRank<T> {
+    fn default() -> Self {
+        Self(HashMap::default())
+    }
+}
+
 impl<T> Debug for DataByRank<T>
 where
     T: Debug,

--- a/src/communication/data_by_rank.rs
+++ b/src/communication/data_by_rank.rs
@@ -97,6 +97,10 @@ impl<T> DataByRank<T> {
     pub fn insert(&mut self, rank: Rank, data: T) {
         self.0.insert(rank, data);
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Rank, &T)> + '_ {
+        self.0.iter()
+    }
 }
 
 impl<T> IntoIterator for DataByRank<T> {
@@ -106,5 +110,11 @@ impl<T> IntoIterator for DataByRank<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl<T> FromIterator<(Rank, T)> for DataByRank<T> {
+    fn from_iter<I: IntoIterator<Item = (Rank, T)>>(iter: I) -> Self {
+        Self(HashMap::from_iter(iter))
     }
 }

--- a/src/communication/data_by_rank.rs
+++ b/src/communication/data_by_rank.rs
@@ -46,9 +46,13 @@ where
     T: Default,
 {
     pub fn from_communicator(communicator: &impl SizedCommunicator) -> Self {
+        Self::from_size_and_rank(communicator.size(), communicator.rank())
+    }
+
+    pub fn from_size_and_rank(size: usize, this_rank: Rank) -> Self {
         Self(
-            (0..communicator.size())
-                .filter(|rank| *rank != communicator.rank() as usize)
+            (0..size)
+                .filter(|rank| *rank != this_rank as usize)
                 .map(|rank| (rank as Rank, T::default()))
                 .collect(),
         )
@@ -56,10 +60,6 @@ where
 }
 
 impl<T> DataByRank<Vec<T>> {
-    pub fn push(&mut self, rank: Rank, data: T) {
-        self.0.get_mut(&rank).unwrap().push(data);
-    }
-
     pub fn drain_all(&mut self) -> impl Iterator<Item = (Rank, Vec<T>)> + '_ {
         self.0.iter_mut().map(|(k, v)| (*k, v.drain(..).collect()))
     }

--- a/src/communication/exchange_communicator.rs
+++ b/src/communication/exchange_communicator.rs
@@ -43,6 +43,19 @@ where
         self.data.push(rank, data);
     }
 
+    pub fn receive(&mut self) -> DataByRank<T> {
+        for (_, data) in self.data.iter() {
+            debug_assert_eq!(data.len(), 1);
+        }
+        let data = self.receive_vec();
+        data.into_iter()
+            .map(|(rank, mut data)| {
+                debug_assert_eq!(data.len(), 1);
+                (rank, data.remove(0))
+            })
+            .collect()
+    }
+
     pub fn send_vec(&mut self, rank: i32, data: Vec<T>) {
         self.data[rank].extend(data)
     }

--- a/src/communication/local.rs
+++ b/src/communication/local.rs
@@ -166,4 +166,20 @@ mod tests {
         comm0.send_vec(1, xs.clone());
         assert_eq!(comm1.receive_vec(0), xs);
     }
+
+    #[test]
+    fn local_communicator_mixed_types() {
+        let mut comms = get_communicators(2, INITIAL_TAG);
+        let mut comm_a0 = comms.remove(&0).unwrap();
+        let mut comm_a1 = comms.remove(&1).unwrap();
+        let mut comms = get_communicators(2, INITIAL_TAG + 1);
+        let mut comm_b0 = comms.remove(&0).unwrap();
+        let mut comm_b1 = comms.remove(&1).unwrap();
+        let xs_a: Vec<i32> = vec![1, 2, 3];
+        let xs_b: Vec<f32> = vec![1.0, 2.0, 3.0];
+        comm_a0.send_vec(1, xs_a.clone());
+        comm_b0.send_vec(1, xs_b.clone());
+        assert_eq!(comm_a1.receive_vec(0), xs_a);
+        assert_eq!(comm_b1.receive_vec(0), xs_b);
+    }
 }

--- a/src/communication/local_app_building.rs
+++ b/src/communication/local_app_building.rs
@@ -63,6 +63,7 @@ pub fn build_local_communication_app_with_custom_logic<
         num_threads,
         0,
     );
+    let mut handles = vec![];
     for rank in 1..num_threads {
         let receivers = Receivers({
             let all = &mut app
@@ -82,13 +83,17 @@ pub fn build_local_communication_app_with_custom_logic<
                 .collect();
             to_move
         });
-        thread::spawn(move || {
-            let mut app =
+        let handle = thread::spawn(move || {
+            let app =
                 create_and_build_app(build_app, receivers, senders, num_threads, rank as Rank);
             custom_logic(app);
         });
+        handles.push(handle);
     }
     custom_logic(app);
+    for handle in handles {
+        handle.join().unwrap();
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Hash)]

--- a/src/communication/local_app_building.rs
+++ b/src/communication/local_app_building.rs
@@ -10,7 +10,6 @@ use mpi::traits::Equivalence;
 use mpi::traits::MatchesRaw;
 use mpi::Tag;
 
-use crate::command_line_options::CommandLineOptions;
 use crate::communication::local::LocalCommunicator;
 use crate::communication::local::Payload;
 use crate::communication::plugin::add_communicator;
@@ -22,38 +21,49 @@ use crate::communication::Rank;
 use crate::communication::SizedCommunicator;
 use crate::communication::WorldRank;
 
-fn create_and_build_app<
-    F: 'static + Sync + Send + Copy + Fn(&mut App, &CommandLineOptions, usize, Rank),
->(
+fn create_and_build_app<F: 'static + Sync + Send + Copy + Fn(&mut App, usize, Rank)>(
     build_app: F,
     receivers: Receivers,
     senders: Senders,
-    opts: &CommandLineOptions,
+    num_threads: usize,
     rank: Rank,
 ) -> App {
     let mut app = App::new();
     app.insert_non_send_resource(receivers);
     app.insert_non_send_resource(senders);
-    build_app(&mut app, opts, opts.num_threads, rank);
+    build_app(&mut app, num_threads, rank);
     app
 }
 
 pub fn build_local_communication_app<
-    F: 'static + Sync + Copy + Send + Fn(&mut App, &CommandLineOptions, usize, Rank),
+    F: 'static + Sync + Copy + Send + Fn(&mut App, usize, Rank),
 >(
     build_app: F,
+    num_threads: usize,
 ) {
-    use clap::Parser;
+    build_local_communication_app_with_custom_logic(
+        build_app,
+        |mut app: App| app.run(),
+        num_threads,
+    );
+}
 
-    let opts = CommandLineOptions::parse();
+pub fn build_local_communication_app_with_custom_logic<
+    F: 'static + Sync + Copy + Send + Fn(&mut App, usize, Rank),
+    G: 'static + Sync + Copy + Send + Fn(App),
+>(
+    build_app: F,
+    custom_logic: G,
+    num_threads: usize,
+) {
     let mut app = create_and_build_app(
         build_app,
         Receivers(HashMap::new()),
         Senders(HashMap::new()),
-        &opts,
+        num_threads,
         0,
     );
-    for rank in 1..opts.num_threads {
+    for rank in 1..num_threads {
         let receivers = Receivers({
             let all = &mut app
                 .world
@@ -72,13 +82,13 @@ pub fn build_local_communication_app<
                 .collect();
             to_move
         });
-        let opts = opts.clone();
         thread::spawn(move || {
-            let mut app = create_and_build_app(build_app, receivers, senders, &opts, rank as Rank);
-            app.run()
+            let mut app =
+                create_and_build_app(build_app, receivers, senders, num_threads, rank as Rank);
+            custom_logic(app);
         });
     }
-    app.run();
+    custom_logic(app);
 }
 
 #[derive(PartialEq, Eq, Debug, Hash)]

--- a/src/communication/mod.rs
+++ b/src/communication/mod.rs
@@ -12,6 +12,7 @@ pub use collective_communicator::CollectiveCommunicator;
 pub use collective_communicator::SumCommunicator;
 pub use data_by_rank::DataByRank;
 pub use identified::Identified;
+pub use plugin::BaseCommunicationPlugin;
 pub use plugin::CommunicationPlugin;
 pub use plugin::CommunicationType;
 pub use sized_communicator::SizedCommunicator;
@@ -30,6 +31,7 @@ pub use local_reexport::*;
 mod local_reexport {
     use super::identified::Identified;
     pub use super::local_app_building::build_local_communication_app;
+    pub use super::local_app_building::build_local_communication_app_with_custom_logic;
 
     pub type AllReduceCommunicator<T> = super::local::LocalCommunicator<T>;
     pub type AllGatherCommunicator<T> = super::local::LocalCommunicator<T>;

--- a/src/communication/plugin.rs
+++ b/src/communication/plugin.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use bevy::prelude::App;
+use bevy::prelude::Plugin;
 use mpi::traits::Equivalence;
 use mpi::traits::MatchesRaw;
 use mpi::Tag;
@@ -8,7 +9,10 @@ use mpi::Tag;
 use super::from_communicator::FromCommunicator;
 use super::Communicator;
 use super::ExchangeCommunicator;
+use super::NumRanks;
+use super::Rank;
 use super::SyncCommunicator;
+use super::WorldRank;
 
 pub(super) const INITIAL_TAG: Tag = 0;
 
@@ -21,6 +25,26 @@ pub enum CommunicationType {
 }
 
 pub(super) struct CurrentTag(pub(super) Tag);
+
+pub struct BaseCommunicationPlugin {
+    num_ranks: NumRanks,
+    world_rank: WorldRank,
+}
+
+impl BaseCommunicationPlugin {
+    pub fn new(size: usize, rank: Rank) -> Self {
+        Self {
+            num_ranks: NumRanks(size),
+            world_rank: WorldRank(rank),
+        }
+    }
+}
+impl Plugin for BaseCommunicationPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(self.world_rank)
+            .insert_resource(self.num_ranks);
+    }
+}
 
 pub struct CommunicationPlugin<T> {
     _marker: PhantomData<T>,

--- a/src/domain/exchange_data_plugin.rs
+++ b/src/domain/exchange_data_plugin.rs
@@ -11,20 +11,22 @@ use bevy::prelude::Res;
 use bevy::prelude::ResMut;
 use bevy::prelude::SystemSet;
 use mpi::traits::Equivalence;
+use mpi::traits::MatchesRaw;
 
 use super::DomainDecompositionStages;
+use crate::communication::CommunicationPlugin;
+use crate::communication::CommunicationType;
 use crate::communication::DataByRank;
 use crate::communication::ExchangeCommunicator;
-use crate::communication::Rank;
 use crate::communication::SizedCommunicator;
 
 struct ExchangePluginExists;
 
+#[derive(Default)]
 struct OutgoingEntities(DataByRank<Vec<Entity>>);
 
+#[derive(Default)]
 struct SpawnedEntities(DataByRank<Vec<Entity>>);
-
-struct NumOutgoingEntities(DataByRank<usize>);
 
 struct ExchangeBuffers<T>(DataByRank<Vec<T>>);
 
@@ -43,25 +45,43 @@ impl<T> Default for ExchangeDataPlugin<T> {
     }
 }
 
-impl<T: Sync + Send + 'static + Component + Clone + Equivalence> Plugin for ExchangeDataPlugin<T> {
+impl<T: Sync + Send + 'static + Component + Clone + Equivalence> Plugin for ExchangeDataPlugin<T>
+where
+    <T as Equivalence>::Out: MatchesRaw,
+{
     fn build(&self, app: &mut bevy::prelude::App) {
         let exists = app.world.get_resource_mut::<ExchangePluginExists>();
         let first = exists.is_none();
         if first {
-            app.world.insert_resource(ExchangePluginExists);
+            app.insert_resource(ExchangePluginExists)
+                .insert_resource(OutgoingEntities::default())
+                .insert_resource(SpawnedEntities::default())
+                .add_plugin(CommunicationPlugin::<NumEntities>::new(
+                    CommunicationType::Exchange,
+                ));
         }
-        app.add_system_set_to_stage(
-            DomainDecompositionStages::Exchange,
-            SystemSet::new()
-                .with_system(Self::fill_buffers_system)
-                .with_system(Self::despawn_outgoing_entities_system)
-                .with_system(Self::send_buffers_system.after(Self::fill_buffers_system))
-                .with_system(Self::receive_buffers_system.after(Self::send_buffers_system)),
-        );
+        app.insert_resource(ExchangeBuffers::<T>(DataByRank::default()))
+            .add_plugin(CommunicationPlugin::<T>::new(CommunicationType::Exchange))
+            .add_system_set_to_stage(
+                DomainDecompositionStages::Exchange,
+                SystemSet::new()
+                    .with_system(Self::fill_buffers_system)
+                    .with_system(Self::despawn_outgoing_entities_system)
+                    .with_system(Self::send_buffers_system.after(Self::fill_buffers_system))
+                    .with_system(
+                        Self::receive_buffers_system
+                            .after(Self::send_buffers_system)
+                            .after(spawn_incoming_entities_system),
+                    ),
+            );
         if first {
             app.add_system_to_stage(
                 DomainDecompositionStages::Exchange,
-                send_num_outgoing_entities_system.after(Self::receive_buffers_system),
+                send_num_outgoing_entities_system,
+            )
+            .add_system_to_stage(
+                DomainDecompositionStages::Exchange,
+                reset_outgoing_entities_system,
             )
             .add_system_to_stage(
                 DomainDecompositionStages::Exchange,
@@ -78,13 +98,16 @@ impl<T: Sync + Send + 'static + Component + Clone + Equivalence> ExchangeDataPlu
         mut buffer: ResMut<ExchangeBuffers<T>>,
     ) {
         for (rank, entities) in entity_exchange.0.iter() {
-            let num_exchanged = entities.len();
             // This allocates a new buffer every time. An alternative would be
             // to keep this at maximum size, trading performance for memory overhead
-            buffer.0.insert(*rank, Vec::with_capacity(num_exchanged));
-            for (i, entity) in entities.iter().enumerate() {
-                buffer.0[*rank as Rank][i] = query.get(*entity).unwrap().clone();
-            }
+            buffer.0.insert(
+                *rank,
+                entities
+                    .iter()
+                    .enumerate()
+                    .map(|(i, entity)| query.get(*entity).unwrap().clone())
+                    .collect(),
+            );
         }
     }
 
@@ -125,10 +148,19 @@ impl<T: Sync + Send + 'static + Component + Clone + Equivalence> ExchangeDataPlu
 
 fn send_num_outgoing_entities_system(
     mut communicator: NonSendMut<ExchangeCommunicator<NumEntities>>,
-    num_outgoing: Res<NumOutgoingEntities>,
+    num_outgoing: Res<OutgoingEntities>,
 ) {
     for rank in communicator.other_ranks() {
-        communicator.send(rank, NumEntities(num_outgoing.0[rank]));
+        communicator.send(
+            rank,
+            NumEntities(
+                num_outgoing
+                    .0
+                    .get(&rank)
+                    .map(|data| data.len())
+                    .unwrap_or(0),
+            ),
+        );
     }
 }
 
@@ -138,11 +170,92 @@ fn spawn_incoming_entities_system(
     mut spawned_entities: ResMut<SpawnedEntities>,
 ) {
     for (rank, num_incoming) in communicator.receive() {
-        spawned_entities.0[rank] = (0..num_incoming.0)
-            .map(|_| {
-                let id = commands.spawn().id();
-                id
-            })
-            .collect();
+        spawned_entities.0.insert(
+            rank,
+            (0..num_incoming.0)
+                .map(|_| {
+                    let id = commands.spawn().id();
+                    id
+                })
+                .collect(),
+        );
+    }
+}
+
+fn reset_outgoing_entities_system(mut outgoing: ResMut<OutgoingEntities>) {
+    *outgoing = OutgoingEntities::default();
+}
+
+#[cfg(test)]
+#[cfg(feature = "local")]
+mod tests {
+    use bevy::prelude::App;
+    use bevy::prelude::Component;
+    use bevy::prelude::CoreStage;
+    use bevy::prelude::SystemStage;
+    use mpi::traits::Equivalence;
+
+    use crate::communication::build_local_communication_app_with_custom_logic;
+    use crate::communication::BaseCommunicationPlugin;
+    use crate::communication::WorldRank;
+    use crate::domain::exchange_data_plugin::ExchangeDataPlugin;
+    use crate::domain::exchange_data_plugin::OutgoingEntities;
+    use crate::domain::DomainDecompositionStages;
+
+    #[derive(Clone, Equivalence, Component)]
+    struct A {
+        x: i32,
+        y: f32,
+    }
+    #[derive(Clone, Equivalence, Component)]
+    struct B {
+        x: i64,
+        y: bool,
+    }
+
+    fn check_received(mut app: App) {
+        let is_main = app.world.get_resource::<WorldRank>().unwrap().is_main();
+        app.update();
+        if !is_main {
+            let mut query = app.world.query::<&mut A>();
+            assert_eq!(query.iter(&app.world).count(), 1);
+        }
+        app.update();
+        if !is_main {
+            let mut query = app.world.query::<&mut A>();
+            assert_eq!(query.iter(&app.world).count(), 1);
+        }
+    }
+
+    #[test]
+    fn exchange_data_plugin() {
+        build_local_communication_app_with_custom_logic(
+            |app, size, rank| build_app(app, size, rank),
+            check_received,
+            2,
+        );
+    }
+
+    fn build_app(app: &mut App, size: usize, rank: i32) {
+        app.add_stage_after(
+            CoreStage::Update,
+            DomainDecompositionStages::Exchange,
+            SystemStage::parallel(),
+        )
+        .add_plugin(BaseCommunicationPlugin::new(size, rank))
+        .add_plugin(ExchangeDataPlugin::<A>::default())
+        .add_plugin(ExchangeDataPlugin::<B>::default());
+        if rank == 0 {
+            let mut entities = vec![];
+            entities.push(
+                app.world
+                    .spawn()
+                    .insert(A { x: 0, y: 5.0 })
+                    .insert(B { x: 0, y: false })
+                    .id(),
+            );
+            let mut outgoing = app.world.get_resource_mut::<OutgoingEntities>().unwrap();
+            outgoing.0.insert(1, entities);
+        }
     }
 }

--- a/src/domain/exchange_data_plugin.rs
+++ b/src/domain/exchange_data_plugin.rs
@@ -1,0 +1,113 @@
+use std::marker::PhantomData;
+
+use bevy::prelude::Entity;
+use bevy::prelude::EventReader;
+use bevy::prelude::ParallelSystemDescriptorCoercion;
+use bevy::prelude::Plugin;
+use bevy::prelude::ResMut;
+use bevy::prelude::SystemSet;
+
+use super::DomainDecompositionStages;
+use crate::communication::Rank;
+
+struct ExchangePluginExists;
+
+struct EntityExchangedEvent {
+    entity: Entity,
+    target_rank: Rank,
+}
+
+struct ExchangeBuffer<T>(Vec<T>);
+
+struct ExchangeDataPlugin<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> Default for ExchangeDataPlugin<T> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData::default(),
+        }
+    }
+}
+
+impl<T: Sync + Send + 'static> Plugin for ExchangeDataPlugin<T> {
+    fn build(&self, app: &mut bevy::prelude::App) {
+        let exists = app.world.get_resource_mut::<ExchangePluginExists>();
+        let first = exists.is_none();
+        if first {
+            app.world.insert_resource(ExchangePluginExists);
+        }
+        app.add_system_set_to_stage(
+            DomainDecompositionStages::Exchange,
+            SystemSet::new()
+                .with_system(Self::prepare_buffers_system)
+                .with_system(Self::fill_buffers_system.after(Self::prepare_buffers_system))
+                .with_system(
+                    Self::despawn_outgoing_entities_system.after(Self::prepare_buffers_system),
+                )
+                .with_system(Self::send_buffers_system.after(Self::fill_buffers_system))
+                .with_system(Self::receive_buffers_system.after(Self::send_buffers_system))
+                .with_system(
+                    Self::insert_incoming_components_system.after(spawn_incoming_entities_system),
+                ),
+        );
+        if first {
+            app.add_system_to_stage(
+                DomainDecompositionStages::Exchange,
+                spawn_incoming_entities_system.after(Self::receive_buffers_system),
+            );
+        }
+    }
+}
+
+impl<T: Sync + Send + 'static> ExchangeDataPlugin<T> {
+    fn prepare_buffers_system(
+        events: EventReader<EntityExchangedEvent>,
+        mut buffer: ResMut<ExchangeBuffer<T>>,
+    ) {
+        let num_exchanged = events.len();
+        // This allocates a new buffer every time. An alternative would be
+        // to keep this at maximum size, trading performance for memory overhead
+        buffer.0 = Vec::with_capacity(num_exchanged);
+    }
+
+    fn fill_buffers_system(
+        events: EventReader<EntityExchangedEvent>,
+        mut buffer: ResMut<ExchangeBuffer<T>>,
+    ) {
+        todo!()
+    }
+
+    fn despawn_outgoing_entities_system(
+        events: EventReader<EntityExchangedEvent>,
+        mut buffer: ResMut<ExchangeBuffer<T>>,
+    ) {
+        todo!()
+    }
+
+    fn send_buffers_system(
+        events: EventReader<EntityExchangedEvent>,
+        mut buffer: ResMut<ExchangeBuffer<T>>,
+    ) {
+        todo!()
+    }
+
+    fn receive_buffers_system(
+        events: EventReader<EntityExchangedEvent>,
+        mut buffer: ResMut<ExchangeBuffer<T>>,
+    ) {
+        todo!()
+    }
+
+    fn insert_incoming_components_system(
+        events: EventReader<EntityExchangedEvent>,
+        mut buffer: ResMut<ExchangeBuffer<T>>,
+    ) {
+        todo!()
+    }
+}
+
+fn spawn_incoming_entities_system(events: EventReader<EntityExchangedEvent>) {
+    todo!()
+}

--- a/src/domain/exchange_data_plugin.rs
+++ b/src/domain/exchange_data_plugin.rs
@@ -1,27 +1,39 @@
 use std::marker::PhantomData;
 
+use bevy::prelude::Commands;
+use bevy::prelude::Component;
 use bevy::prelude::Entity;
-use bevy::prelude::EventReader;
+use bevy::prelude::NonSendMut;
 use bevy::prelude::ParallelSystemDescriptorCoercion;
 use bevy::prelude::Plugin;
+use bevy::prelude::Query;
+use bevy::prelude::Res;
 use bevy::prelude::ResMut;
 use bevy::prelude::SystemSet;
+use mpi::traits::Equivalence;
 
 use super::DomainDecompositionStages;
+use crate::communication::DataByRank;
+use crate::communication::ExchangeCommunicator;
 use crate::communication::Rank;
+use crate::communication::SizedCommunicator;
 
 struct ExchangePluginExists;
 
-struct EntityExchangedEvent {
-    entity: Entity,
-    target_rank: Rank,
-}
+struct OutgoingEntities(DataByRank<Vec<Entity>>);
 
-struct ExchangeBuffer<T>(Vec<T>);
+struct SpawnedEntities(DataByRank<Vec<Entity>>);
+
+struct NumOutgoingEntities(DataByRank<usize>);
+
+struct ExchangeBuffers<T>(DataByRank<Vec<T>>);
 
 struct ExchangeDataPlugin<T> {
     _marker: PhantomData<T>,
 }
+
+#[derive(Equivalence)]
+struct NumEntities(usize);
 
 impl<T> Default for ExchangeDataPlugin<T> {
     fn default() -> Self {
@@ -31,7 +43,7 @@ impl<T> Default for ExchangeDataPlugin<T> {
     }
 }
 
-impl<T: Sync + Send + 'static> Plugin for ExchangeDataPlugin<T> {
+impl<T: Sync + Send + 'static + Component + Clone + Equivalence> Plugin for ExchangeDataPlugin<T> {
     fn build(&self, app: &mut bevy::prelude::App) {
         let exists = app.world.get_resource_mut::<ExchangePluginExists>();
         let first = exists.is_none();
@@ -41,73 +53,96 @@ impl<T: Sync + Send + 'static> Plugin for ExchangeDataPlugin<T> {
         app.add_system_set_to_stage(
             DomainDecompositionStages::Exchange,
             SystemSet::new()
-                .with_system(Self::prepare_buffers_system)
-                .with_system(Self::fill_buffers_system.after(Self::prepare_buffers_system))
-                .with_system(
-                    Self::despawn_outgoing_entities_system.after(Self::prepare_buffers_system),
-                )
+                .with_system(Self::fill_buffers_system)
+                .with_system(Self::despawn_outgoing_entities_system)
                 .with_system(Self::send_buffers_system.after(Self::fill_buffers_system))
-                .with_system(Self::receive_buffers_system.after(Self::send_buffers_system))
-                .with_system(
-                    Self::insert_incoming_components_system.after(spawn_incoming_entities_system),
-                ),
+                .with_system(Self::receive_buffers_system.after(Self::send_buffers_system)),
         );
         if first {
             app.add_system_to_stage(
                 DomainDecompositionStages::Exchange,
-                spawn_incoming_entities_system.after(Self::receive_buffers_system),
+                send_num_outgoing_entities_system.after(Self::receive_buffers_system),
+            )
+            .add_system_to_stage(
+                DomainDecompositionStages::Exchange,
+                spawn_incoming_entities_system.after(send_num_outgoing_entities_system),
             );
         }
     }
 }
 
-impl<T: Sync + Send + 'static> ExchangeDataPlugin<T> {
-    fn prepare_buffers_system(
-        events: EventReader<EntityExchangedEvent>,
-        mut buffer: ResMut<ExchangeBuffer<T>>,
-    ) {
-        let num_exchanged = events.len();
-        // This allocates a new buffer every time. An alternative would be
-        // to keep this at maximum size, trading performance for memory overhead
-        buffer.0 = Vec::with_capacity(num_exchanged);
-    }
-
+impl<T: Sync + Send + 'static + Component + Clone + Equivalence> ExchangeDataPlugin<T> {
     fn fill_buffers_system(
-        events: EventReader<EntityExchangedEvent>,
-        mut buffer: ResMut<ExchangeBuffer<T>>,
+        entity_exchange: Res<OutgoingEntities>,
+        query: Query<&T>,
+        mut buffer: ResMut<ExchangeBuffers<T>>,
     ) {
-        todo!()
+        for (rank, entities) in entity_exchange.0.iter() {
+            let num_exchanged = entities.len();
+            // This allocates a new buffer every time. An alternative would be
+            // to keep this at maximum size, trading performance for memory overhead
+            buffer.0.insert(*rank, Vec::with_capacity(num_exchanged));
+            for (i, entity) in entities.iter().enumerate() {
+                buffer.0[*rank as Rank][i] = query.get(*entity).unwrap().clone();
+            }
+        }
     }
 
     fn despawn_outgoing_entities_system(
-        events: EventReader<EntityExchangedEvent>,
-        mut buffer: ResMut<ExchangeBuffer<T>>,
+        mut commands: Commands,
+        entity_exchange: Res<OutgoingEntities>,
     ) {
-        todo!()
+        for (_, entities) in entity_exchange.0.iter() {
+            for entity in entities {
+                commands.entity(*entity).despawn();
+            }
+        }
     }
 
     fn send_buffers_system(
-        events: EventReader<EntityExchangedEvent>,
-        mut buffer: ResMut<ExchangeBuffer<T>>,
+        mut communicator: NonSendMut<ExchangeCommunicator<T>>,
+        mut buffers: ResMut<ExchangeBuffers<T>>,
     ) {
-        todo!()
+        for (rank, data) in buffers.0.drain_all() {
+            communicator.send_vec(rank, data);
+        }
     }
 
     fn receive_buffers_system(
-        events: EventReader<EntityExchangedEvent>,
-        mut buffer: ResMut<ExchangeBuffer<T>>,
+        mut commands: Commands,
+        mut communicator: NonSendMut<ExchangeCommunicator<T>>,
+        spawned_entities: Res<SpawnedEntities>,
     ) {
-        todo!()
-    }
-
-    fn insert_incoming_components_system(
-        events: EventReader<EntityExchangedEvent>,
-        mut buffer: ResMut<ExchangeBuffer<T>>,
-    ) {
-        todo!()
+        for (rank, data) in communicator.receive_vec() {
+            let spawned_entities = spawned_entities.0[rank].clone();
+            let iterator = spawned_entities
+                .into_iter()
+                .zip(data.into_iter().map(|component| (component,)));
+            commands.insert_or_spawn_batch(iterator);
+        }
     }
 }
 
-fn spawn_incoming_entities_system(events: EventReader<EntityExchangedEvent>) {
-    todo!()
+fn send_num_outgoing_entities_system(
+    mut communicator: NonSendMut<ExchangeCommunicator<NumEntities>>,
+    num_outgoing: Res<NumOutgoingEntities>,
+) {
+    for rank in communicator.other_ranks() {
+        communicator.send(rank, NumEntities(num_outgoing.0[rank]));
+    }
+}
+
+fn spawn_incoming_entities_system(
+    mut commands: Commands,
+    mut communicator: NonSendMut<ExchangeCommunicator<NumEntities>>,
+    mut spawned_entities: ResMut<SpawnedEntities>,
+) {
+    for (rank, num_incoming) in communicator.receive() {
+        spawned_entities.0[rank] = (0..num_incoming.0)
+            .map(|_| {
+                let id = commands.spawn().id();
+                id
+            })
+            .collect();
+    }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use mpi::traits::Equivalence;
 
+mod exchange_data_plugin;
 mod extent;
 mod peano_hilbert;
 pub mod quadtree;
@@ -33,6 +34,7 @@ const NUM_DESIRED_SEGMENTS_PER_RANK: usize = 50;
 #[derive(StageLabel)]
 pub enum DomainDecompositionStages {
     Decomposition,
+    Exchange,
 }
 
 pub struct DomainDecompositionPlugin;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -47,6 +47,11 @@ impl Plugin for DomainDecompositionPlugin {
             DomainDecompositionStages::Decomposition,
             SystemStage::parallel(),
         );
+        app.add_stage_after(
+            DomainDecompositionStages::Decomposition,
+            DomainDecompositionStages::Exchange,
+            SystemStage::parallel(),
+        );
         app.add_system_to_stage(
             DomainDecompositionStages::Decomposition,
             determine_global_extent_system,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -7,6 +7,8 @@ mod peano_hilbert;
 pub mod quadtree;
 mod segment;
 
+pub use self::exchange_data_plugin::ExchangeDataPlugin;
+use self::exchange_data_plugin::OutgoingEntities;
 use self::extent::Extent;
 use self::peano_hilbert::PeanoHilbertKey;
 use self::segment::get_segments;
@@ -24,7 +26,6 @@ use crate::communication::SumCommunicator;
 use crate::communication::WorldRank;
 use crate::domain::segment::merge_and_split_segments;
 use crate::mass::Mass;
-use crate::particle::LocalParticleBundle;
 use crate::physics::LocalParticle;
 use crate::position::Position;
 use crate::velocity::Velocity;
@@ -60,9 +61,6 @@ impl Plugin for DomainDecompositionPlugin {
             DomainDecompositionStages::Decomposition,
             domain_decomposition_system.after(determine_global_extent_system),
         )
-        .add_plugin(CommunicationPlugin::<ParticleExchangeData>::new(
-            CommunicationType::Exchange,
-        ))
         .add_plugin(CommunicationPlugin::<Extent>::new(
             CommunicationType::AllGather,
         ))
@@ -89,7 +87,7 @@ impl ParticleData {
 }
 
 fn determine_global_extent_system(
-    particles: Query<&Position, With<LocalParticle>>,
+    particles: Query<&Position>,
     mut extent_communicator: NonSendMut<AllGatherCommunicator<Extent>>,
     mut global_extent: ResMut<GlobalExtent>,
 ) {
@@ -165,15 +163,13 @@ fn find_key_cutoffs(
 }
 
 fn domain_decomposition_system(
-    mut commands: Commands,
     mut segment_communicator: NonSendMut<ExchangeCommunicator<Segment>>,
-    mut exchange_communicator: NonSendMut<ExchangeCommunicator<ParticleExchangeData>>,
     mut num_particle_communicator: NonSendMut<AllReduceCommunicator<usize>>,
+    mut outgoing_entities: ResMut<OutgoingEntities>,
     rank: Res<WorldRank>,
     num_ranks: Res<NumRanks>,
     extent: Res<GlobalExtent>,
     particles: Query<(Entity, &Position), With<LocalParticle>>,
-    full_particle_data: Query<(&Position, &Velocity, &Mass), With<LocalParticle>>,
 ) {
     let particles = get_sorted_peano_hilbert_keys(&extent.0, &particles);
     let num_particles_total =
@@ -193,24 +189,7 @@ fn domain_decomposition_system(
     for ParticleData { key, entity } in particles.iter() {
         let target_rank = target_rank(key);
         if target_rank != rank.0 {
-            commands.entity(*entity).despawn();
-            let (pos, vel, mass) = full_particle_data.get(*entity).unwrap();
-            exchange_communicator.send(
-                target_rank,
-                ParticleExchangeData {
-                    pos: pos.clone(),
-                    vel: vel.clone(),
-                    mass: mass.clone(),
-                },
-            );
-        }
-    }
-
-    for (_, moved_to_own_domain) in exchange_communicator.receive_vec().into_iter() {
-        for data in moved_to_own_domain.into_iter() {
-            commands
-                .spawn()
-                .insert_bundle(LocalParticleBundle::new(data.pos, data.vel, data.mass));
+            outgoing_entities.add(target_rank, *entity);
         }
     }
 }

--- a/src/initial_conditions.rs
+++ b/src/initial_conditions.rs
@@ -24,7 +24,7 @@ fn spawn_particles_system(mut commands: Commands, rank: Res<WorldRank>) {
     if !rank.is_main() {
         return;
     }
-    let n_particles = 150;
+    let n_particles = 10;
     for _ in 0..n_particles {
         let x = rand::thread_rng().gen_range(-5.0..-4.0);
         let y = rand::thread_rng().gen_range(-1.0..1.0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,6 @@ use bevy::prelude::ParallelSystemDescriptorCoercion;
 use bevy::prelude::Res;
 use command_line_options::CommandLineOptions;
 use communication::BaseCommunicationPlugin;
-use communication::NumRanks;
-use communication::WorldRank;
 use domain::DomainDecompositionPlugin;
 use initial_conditions::InitialConditionsPlugin;
 use parameters::add_parameter_file_contents;

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -11,6 +11,8 @@ use self::parameters::Parameters;
 use crate::communication::Rank;
 use crate::domain::quadtree::QuadTreeConfig;
 use crate::domain::DomainDecompositionStages;
+use crate::domain::ExchangeDataPlugin;
+use crate::mass::Mass;
 use crate::parameters::ParameterPlugin;
 use crate::position::Position;
 use crate::units;
@@ -50,6 +52,9 @@ impl Plugin for PhysicsPlugin {
         );
         app.add_plugin(ParameterPlugin::<Parameters>::new("physics"))
             .add_plugin(ParameterPlugin::<QuadTreeConfig>::new("tree"))
+            .add_plugin(ExchangeDataPlugin::<Position>::default())
+            .add_plugin(ExchangeDataPlugin::<Velocity>::default())
+            .add_plugin(ExchangeDataPlugin::<Mass>::default())
             .insert_resource(Timestep(units::Time::second(0.01)))
             .insert_resource(Time(units::Time::second(0.00)))
             .add_system_to_stage(


### PR DESCRIPTION
Fixes #26.

Any component that needs to be synchronized to other ranks (i.e. belongs to a "particle") can be registered using

`app.add_plugin(ExchangeDataPlugin::<Component>::default())`.

The rest will be done automatically.